### PR TITLE
Allow ref forwarding

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import {
   ImageUploadingPropsType,
   ErrorsType,
   ResolutionType,
+  ExportInterface
 } from "./typings";
 
 const { useRef, useState, useCallback } = React;
@@ -17,7 +18,10 @@ const defaultErrors: ErrorsType = {
   resolution: false,
 };
 
-const ImageUploading: React.FC<ImageUploadingPropsType> = ({
+const ImageUploading: React.RefForwardingComponent<
+ExportInterface,
+ImageUploadingPropsType
+> = ({
   multiple,
   onChange,
   maxNumber,
@@ -29,7 +33,7 @@ const ImageUploading: React.FC<ImageUploadingPropsType> = ({
   resolutionHeight,
   resolutionType,
   onError,
-}) => {
+}, ref) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [imageList, setImageList] = useState(() => {
     let initImageList: Array<ImageType> = [];
@@ -204,6 +208,13 @@ const ImageUploading: React.FC<ImageUploadingPropsType> = ({
     if (inputRef.current) inputRef.current.value = "";
   };
 
+  React.useImperativeHandle(ref, () => ({
+    imageList,
+    onImageUpload,
+    onImageRemoveAll,
+    errors
+  }));
+
   const acceptString =
     acceptType && acceptType.length > 0
       ? acceptType.map((item) => `.${item}`).join(", ")
@@ -236,7 +247,7 @@ ImageUploading.defaultProps = {
   acceptType: [],
 };
 
-export default ImageUploading;
+export default React.forwardRef(ImageUploading);
 
 export {
   ImageType,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,17 +22,17 @@ const ImageUploading: React.RefForwardingComponent<
 ExportInterface,
 ImageUploadingPropsType
 > = ({
-  multiple,
   onChange,
-  maxNumber,
   children,
   defaultValue,
-  acceptType,
   maxFileSize,
   resolutionWidth,
   resolutionHeight,
   resolutionType,
   onError,
+  maxNumber = 1000,
+  multiple = false,
+  acceptType = [],
 }, ref) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [imageList, setImageList] = useState(() => {
@@ -239,12 +239,6 @@ ImageUploadingPropsType
         })}
     </>
   );
-};
-
-ImageUploading.defaultProps = {
-  maxNumber: 1000,
-  multiple: false,
-  acceptType: [],
 };
 
 export default React.forwardRef(ImageUploading);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {
   ImageUploadingPropsType,
   ErrorsType,
   ResolutionType,
-  ExportInterface
+  ImageUploadingRef
 } from "./typings";
 
 const { useRef, useState, useCallback } = React;
@@ -19,7 +19,7 @@ const defaultErrors: ErrorsType = {
 };
 
 const ImageUploading: React.RefForwardingComponent<
-ExportInterface,
+ImageUploadingRef,
 ImageUploadingPropsType
 > = ({
   onChange,
@@ -249,4 +249,5 @@ export {
   ImageUploadingPropsType,
   ErrorsType,
   ResolutionType,
+  ImageUploadingRef
 };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -29,6 +29,8 @@ export interface ExportInterface {
   errors: Record<string, any>;
 }
 
+export type ImageUploadingRef = ExportInterface
+
 export type ErrorsType = {
   maxFileSize: boolean;
   maxNumber: boolean;


### PR DESCRIPTION
Hi! Thanks for the component, it is very helpful but i have hit a limitation as i needed to call the `onImageRemoveAll` from a hook function. I could have by passed such method from the render itself but i don't like the approach and thats why i've implemented the ability to use a ref and expose the same methods offered in render.

If you accept this PR please consider the React docs [advice](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers) in order to bump the release version.

