### PR TITLE
:sparkles: resolutionType can accept an array of enums

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {
   ImageListType,
   ImageUploadingPropsType,
   ErrorsType,
-  ResolutionType,
+  ResolutionTypes,
 } from './typings';
 import {
   DEFAULT_NULL_INDEX,
@@ -184,7 +184,7 @@ const ReactImageUploading: React.FC<ImageUploadingPropsType> = ({
           onDragEnter: handleDragIn,
           onDragLeave: handleDragOut,
           onDragOver: handleDrag,
-          onDragStart:handleDragStart,
+          onDragStart: handleDragStart,
         },
         isDragging,
       })}
@@ -199,5 +199,5 @@ export {
   ImageListType,
   ImageUploadingPropsType,
   ErrorsType,
-  ResolutionType,
+  ResolutionTypes,
 };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -18,7 +18,7 @@ export interface ImageUploadingPropsType {
   maxFileSize?: number;
   resolutionWidth?: number;
   resolutionHeight?: number;
-  resolutionType?: ResolutionType;
+  resolutionType?: ResolutionTypes;
   onError?: (errors: ErrorsType, files?: ImageListType) => void;
   dataURLKey?: string;
   inputProps?: React.HTMLProps<HTMLInputElement>;
@@ -49,3 +49,6 @@ export type ErrorsType = {
 } | null;
 
 export type ResolutionType = 'absolute' | 'less' | 'more' | 'ratio';
+export type ResolutionTypes =
+  | string
+  | Array<'absolute' | 'less' | 'more' | 'ratio'>;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_NULL_INDEX } from './constants';
-import { ResolutionType, ErrorsType } from './typings';
+import { ResolutionTypes, ErrorsType } from './typings';
 import { getImage } from './utils';
 
 export const isResolutionValid = (
   image: HTMLImageElement,
-  resolutionType: ResolutionType,
+  resolutionType: ResolutionTypes,
   resolutionWidth: number = 0,
   resolutionHeight: number = 1
 ): boolean => {
@@ -100,16 +100,32 @@ export const getErrorValidation = async ({
         break;
       }
       if (resolutionType) {
-        const image = await getImage(file);
-        const checkRes = isResolutionValid(
-          image,
-          resolutionType,
-          resolutionWidth,
-          resolutionHeight
-        );
-        if (!checkRes) {
-          newErrors.resolution = true;
-          break;
+        if (typeof resolutionType === 'string') {
+          const image = await getImage(file);
+          const checkRes = isResolutionValid(
+            image,
+            resolutionType,
+            resolutionWidth,
+            resolutionHeight
+          );
+          if (!checkRes) {
+            newErrors.resolution = true;
+            break;
+          }
+        } else {
+          const image = await getImage(file);
+          for (let j = 0; j < resolutionType.length; j += 1) {
+            const checkRes = isResolutionValid(
+              image,
+              resolutionType[j],
+              resolutionWidth,
+              resolutionHeight
+            );
+            if (!checkRes) {
+              newErrors.resolution = true;
+              break;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Possible accepted values in `resolutionType` (when passed as array) are `'absolute' | 'less' | 'more' | 'ratio'`

For Example: 
```
resolutionType={['ratio', 'more']}
```