### PR TITLE
:sparkles: add new resolutionType ratioWithMinDimensions

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -48,4 +48,9 @@ export type ErrorsType = {
   resolution?: boolean;
 } | null;
 
-export type ResolutionType = 'absolute' | 'less' | 'more' | 'ratio';
+export type ResolutionType =
+  | 'absolute'
+  | 'less'
+  | 'more'
+  | 'ratio'
+  | 'ratioWithMinDimensions';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -31,6 +31,16 @@ export const isResolutionValid = (
         return true;
       break;
     }
+    case 'ratioWithMinDimensions': {
+      const ratio = resolutionWidth / resolutionHeight;
+      if (
+        image.width / image.height === ratio &&
+        image.width >= resolutionWidth &&
+        image.height >= resolutionHeight
+      )
+        return true;
+      break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
The new `resolutionType` acts as a combination of 'absolute' and 'more' 